### PR TITLE
Fix textarea "codemirror-config" attribute value format

### DIFF
--- a/src/main/resources/io/jenkins/plugins/globalyamlproperties/MultibranchYAMLJobProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/globalyamlproperties/MultibranchYAMLJobProperty/config.jelly
@@ -7,7 +7,7 @@
                     title="ReadOnly" tooltip="${%config.checkbox.tooltip}" />
         <f:description>${%config.description}</f:description>
         <f:entry title="${%config.title}" field="yamlConfiguration">
-            <f:textarea name="yamlConfiguration" codemirror-mode="yaml" codemirror-config="mode: 'text/x-yaml', readOnly: true, lineNumbers: true, lineWrapping: true" value="${it.yamlConfiguration}"/>
+            <f:textarea name="yamlConfiguration" codemirror-mode="yaml" codemirror-config='"mode": "text/x-yaml", "readOnly": true, "lineNumbers": true, "lineWrapping": true' value="${it.yamlConfiguration}"/>
             <script type="text/javascript">
                 document.addEventListener("DOMContentLoaded", function() {
                 var configForm = document.forms['config']; // This usually targets the job configuration form in Jenkins

--- a/src/main/resources/io/jenkins/plugins/globalyamlproperties/PipelineYAMLJobProperty/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/globalyamlproperties/PipelineYAMLJobProperty/config.jelly
@@ -7,7 +7,7 @@
                     title="ReadOnly" tooltip="${%config.checkbox.tooltip}" />
         <f:description>${%config.description}</f:description>
         <f:entry title="${%config.title}" field="yamlConfiguration">
-            <f:textarea name="yamlConfiguration" codemirror-mode="yaml" codemirror-config="mode: 'text/x-yaml', readOnly: true, lineNumbers: true, lineWrapping: true" value="${it.yamlConfiguration}"/>
+            <f:textarea name="yamlConfiguration" codemirror-mode="yaml" codemirror-config='"mode": "text/x-yaml", "readOnly": true, "lineNumbers": true, "lineWrapping": true' value="${it.yamlConfiguration}"/>
             <script type="text/javascript">
                 document.addEventListener("DOMContentLoaded", function() {
                 var configForm = document.forms['config']; // This usually targets the job configuration form in Jenkins


### PR DESCRIPTION
Historically CodeMirror supports invalid JSON inside codemirror-config attribute, but since now it needs to be properly quoted.
